### PR TITLE
[Fix][UIKit][iOS 26] Bug on toggle size

### DIFF
--- a/Sources/Core/View/UIKit/SwitchUIView.swift
+++ b/Sources/Core/View/UIKit/SwitchUIView.swift
@@ -522,6 +522,8 @@ public final class SwitchUIView: UIView {
 
         self.toggleView.layoutIfNeeded()
         self.toggleView.setCornerRadius(self.theme.border.radius.full)
+
+        self.toggleDotView.layoutIfNeeded()
         self.toggleDotView.setCornerRadius(self.theme.border.radius.full)
     }
 

--- a/Sources/Core/ViewModel/SwitchViewModel.swift
+++ b/Sources/Core/ViewModel/SwitchViewModel.swift
@@ -43,7 +43,7 @@ final class SwitchViewModel: ObservableObject {
     @Published private(set) var toggleDotImagesState: SwitchImagesState?
 
     @Published private(set) var displayedText: DisplayedText?
-    @Published private(set) var textFontToken: TypographyFontToken?
+    @Published private(set) var textFontToken: (any TypographyFontToken)?
 
     // MARK: - Private Properties
 

--- a/Tests/UnitTests/ViewModel/SwitchViewModelTests.swift
+++ b/Tests/UnitTests/ViewModel/SwitchViewModelTests.swift
@@ -1494,7 +1494,7 @@ private final class Stub {
     let showToggleLeftSpacePublisherMock: PublisherMock<Published<Bool?>.Publisher>
     let toggleDotImagesStatePublisherMock: PublisherMock<Published<SwitchImagesState?>.Publisher>
     let displayedTextPublisherMock: PublisherMock<Published<DisplayedText?>.Publisher>
-    let textFontTokenPublisherMock: PublisherMock<Published<TypographyFontToken?>.Publisher>
+    let textFontTokenPublisherMock: PublisherMock<Published<(any TypographyFontToken)?>.Publisher>
 
     // MARK: - Initialization
 


### PR DESCRIPTION
On iOS 26, the dot inside the toggle is a square. This PR fix this issue.